### PR TITLE
Fix generation of asteroid belts when created from planets down-system from gas giants.

### DIFF
--- a/js/planet-generator.js
+++ b/js/planet-generator.js
@@ -136,7 +136,6 @@ window.planetGenerator = (function () {
         }
         else if(zone == "black") {
             planet = rollHelper.rollArray(planetGenerator.blackZoneTable);
-            orbitRollModifier++;
         }
         else {
             return null;
@@ -147,6 +146,9 @@ window.planetGenerator = (function () {
 
     function initializePlanet(planet, zone) {
         var orbitRollModifier = 0;
+        if(zone == "black") {
+            orbitRollModifier++;
+        }
 
         // Parent
         planet.result.parent = "star";

--- a/js/planet-generator.js
+++ b/js/planet-generator.js
@@ -142,10 +142,10 @@ window.planetGenerator = (function () {
             return null;
         }
 
-        return planetGenerator.generatePlanet(planet, zone);
+        return initializePlanet(planet, zone);
     }
 
-    function generatePlanet(planet, zone) {
+    function initializePlanet(planet, zone) {
         var orbitRollModifier = 0;
 
         // Parent
@@ -218,7 +218,7 @@ window.planetGenerator = (function () {
             }
         };
 
-        return planetGenerator.generatePlanet(planet, zone);
+        return initializePlanet(planet, zone);
     }
 
     function getDayLength(planet) {

--- a/js/planet-generator.js
+++ b/js/planet-generator.js
@@ -119,7 +119,6 @@ window.planetGenerator = (function () {
 
     function roll(zone) {
         var planet = null;
-        var orbitRollModifier = 0;
 
         if(typeof zone == "undefined" || zone == "") { return null; }
 
@@ -142,6 +141,12 @@ window.planetGenerator = (function () {
         else {
             return null;
         }
+
+        return planetGenerator.generatePlanet(planet, zone);
+    }
+
+    function generatePlanet(planet, zone) {
+        var orbitRollModifier = 0;
 
         // Parent
         planet.result.parent = "star";
@@ -203,7 +208,7 @@ window.planetGenerator = (function () {
         return planet;
     }
 
-    function getAsteroidBelt() {
+    function getAsteroidBelt(zone) {
         var planet = {
             result: resultHelper.clone(planetGenerator.getTable().find(element => element.code == "planet.asteroidBelt")),
             roll: {
@@ -213,21 +218,7 @@ window.planetGenerator = (function () {
             }
         };
 
-        // Roll Details
-        planet.result.age = localChance.natural({min: planet.result.age_min, max: planet.result.age_max});
-        planet.result.density = planetFunctions.getDensity(planet.result), "";
-        planet.result.mass = 0;
-        planet.result.diameter = 0;
-        planet.result.radius = 0;
-        planet.result.planetaryRadius = 0;
-        planet.result.gravity = 0;
-        planet.result.orbit = planetFunctions.getOrbit({ total: 6 });
-        planet.result.inclination = planetFunctions.getInclination(planet.roll.inclination);
-        planet.result.satelliteCount = 0;
-        planet.result.atmosphere = { name: "None", code: "atmosphere.none", density: 0 };
-        planet.result.life = {name: "None", code: "life.none", order: 0};
-
-        return planet;
+        return planetGenerator.generatePlanet(planet, zone);
     }
 
     function getDayLength(planet) {

--- a/js/planetary-system-generator.js
+++ b/js/planetary-system-generator.js
@@ -528,11 +528,10 @@ window.planetarySystemGenerator = (function () {
 
             if((curPlanet.code == "planet.class.j" || curPlanet.code == "planet.class.s" || curPlanet.code == "planet.class.u")
                     && (prevPlanet.code != "planet.class.j" && prevPlanet.code != "planet.class.s" && prevPlanet.code != "planet.class.u")) {
-                planets[i-1] = planetGenerator.getAsteroidBelt().result;
+                planets[i-1] = planetGenerator.getAsteroidBelt(prevPlanet.zone).result;
                 planets[i-1].baseType = baseType;
                 planets[i-1].parentType = baseType;
                 planets[i-1].orbitalPeriod = 0;
-                planets[i-1].zone = prevPlanet.zone;
                 planets[i-1].distance = prevPlanet.distance;
             }
         }


### PR DESCRIPTION
The code that generates asteroid belts from scratch works, but when a smaller planet is nearer the sun than a gas giant the code that converted it to an asteroid belt had several deficiencies.  This change refactors the code that generates an asteroid belt and calls the same code in either case so it's consistent.

Tested on another server, and both types of asteroid belts now correctly display details.